### PR TITLE
Rename project to ngx gallery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `[doeMedia]` directive, which is to be used in custom item templates (`[itemTemplate]` @Input). It is not mandatory, but if used it makes the gallery aware of the custom provided media (`<img>` or `<video>`), them failing or successfully loading in particular. Without it, the user is responsible for providing some kind of a loading animation and, if needed, reflect on failure to load media, himself.
+- Added `[media]` directive, which is to be used in custom item templates (`[itemTemplate]` @Input). It is not mandatory, but if used it makes the gallery aware of the custom provided media (`<img>` or `<video>`), them failing or successfully loading in particular. Without it, the user is responsible for providing some kind of a loading animation and, if needed, reflect on failure to load media, himself.
 - Gallery now loads only those media, that are displayed in the scrollport of the gallery. Once there is an interaction though of any kind with the gallery, it starts preloading also item which are in immediate proximity of the scrollport, but not visible yet. This is done to improve first load performance.
 - Item enter animation in form of a fade-in.
 
@@ -130,15 +130,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed background flashes in Firefox when new images slide into doe-viewer's scrollport.
 
-[unreleased]: https://github.com/daelmaak/ngx-doe-gallery/compare/v1.1.3...HEAD
-[1.1.3]: https://github.com/daelmaak/ngx-doe-gallery/compare/v1.1.3...v1.1.2
-[1.1.2]: https://github.com/daelmaak/ngx-doe-gallery/compare/v1.1.2...v1.1.1
-[1.1.1]: https://github.com/daelmaak/ngx-doe-gallery/compare/v1.1.1...v1.1.0
-[1.1.0]: https://github.com/daelmaak/ngx-doe-gallery/compare/v1.1.0...v1.1.0-RC1
-[1.1.0-rc1]: https://github.com/daelmaak/ngx-doe-gallery/compare/v1.1.0-RC1...v1.0.0
-[1.0.0]: https://github.com/daelmaak/ngx-doe-gallery/compare/v1.0.0-beta.3...v1.0.0
-[1.0.0-beta.3]: https://github.com/daelmaak/ngx-doe-gallery/compare/v1.0.0-beta.2...v1.0.0-beta.3
-[1.0.0-beta.2]: https://github.com/daelmaak/ngx-doe-gallery/compare/v1.0.0-beta.0...v1.0.0-beta.2
-[1.0.0-beta.0]: https://github.com/daelmaak/ngx-doe-gallery/compare/v1.0.0-alpha.1...v1.0.0-beta.0
-[1.0.0-alpha.1]: https://github.com/daelmaak/ngx-doe-gallery/compare/v1.0.0-alpha.0...v1.0.0-alpha.1
-[1.0.0-alpha.0]: https://github.com/daelmaak/ngx-doe-gallery/compare/v0.1.0-alpha.6...v1.0.0-alpha.0
+[unreleased]: https://github.com/daelmaak/ngx-gallery/compare/v1.1.3...HEAD
+[1.1.3]: https://github.com/daelmaak/ngx-gallery/compare/v1.1.3...v1.1.2
+[1.1.2]: https://github.com/daelmaak/ngx-gallery/compare/v1.1.2...v1.1.1
+[1.1.1]: https://github.com/daelmaak/ngx-gallery/compare/v1.1.1...v1.1.0
+[1.1.0]: https://github.com/daelmaak/ngx-gallery/compare/v1.1.0...v1.1.0-RC1
+[1.1.0-rc1]: https://github.com/daelmaak/ngx-gallery/compare/v1.1.0-RC1...v1.0.0
+[1.0.0]: https://github.com/daelmaak/ngx-gallery/compare/v1.0.0-beta.3...v1.0.0
+[1.0.0-beta.3]: https://github.com/daelmaak/ngx-gallery/compare/v1.0.0-beta.2...v1.0.0-beta.3
+[1.0.0-beta.2]: https://github.com/daelmaak/ngx-gallery/compare/v1.0.0-beta.0...v1.0.0-beta.2
+[1.0.0-beta.0]: https://github.com/daelmaak/ngx-gallery/compare/v1.0.0-alpha.1...v1.0.0-beta.0
+[1.0.0-alpha.1]: https://github.com/daelmaak/ngx-gallery/compare/v1.0.0-alpha.0...v1.0.0-alpha.1
+[1.0.0-alpha.0]: https://github.com/daelmaak/ngx-gallery/compare/v0.1.0-alpha.6...v1.0.0-alpha.0

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Performant, responsive, easy to use Angular **8+** gallery
 
 [![codecov](https://codecov.io/gh/daelmaak/ngx-gallery/branch/master/graph/badge.svg?token=eQhl2BmseY)](https://codecov.io/gh/daelmaak/ngx-gallery)
-[![npm](https://img.shields.io/npm/v/ngx-gallery.svg)](https://www.npmjs.com/package/ngx-gallery)
+[![npm](https://img.shields.io/npm/v/daelmaak/ngx-gallery.svg)](https://www.npmjs.com/package/daelmaak/ngx-gallery)
 
 [**Demos**](https://daelmaak.github.io/ngx-gallery/) |
 [**Docs**](https://github.com/daelmaak/ngx-gallery/wiki/Gallery-API/cc4f9ed153dd3362aef704cea5bc3eb4c3f34397) |

--- a/README.md
+++ b/README.md
@@ -1,22 +1,18 @@
-<div align="center">
-<img src="https://daelmaak.github.io/ngx-doe-gallery/assets/icons/doe.png" width="90">
-</div>
-
-# Doe Gallery
+# Ngx Gallery
 
 Performant, responsive, easy to use Angular **8+** gallery
 
 [![codecov](https://codecov.io/gh/daelmaak/ngx-gallery/branch/master/graph/badge.svg?token=eQhl2BmseY)](https://codecov.io/gh/daelmaak/ngx-gallery)
-[![npm](https://img.shields.io/npm/v/ngx-doe-gallery.svg)](https://www.npmjs.com/package/ngx-doe-gallery)
+[![npm](https://img.shields.io/npm/v/ngx-gallery.svg)](https://www.npmjs.com/package/ngx-gallery)
 
-[**Demos**](https://daelmaak.github.io/ngx-doe-gallery/) |
+[**Demos**](https://daelmaak.github.io/ngx-gallery/) |
 [**Docs**](https://github.com/daelmaak/ngx-gallery/wiki/Gallery-API/cc4f9ed153dd3362aef704cea5bc3eb4c3f34397) |
-[**Changelog**](https://github.com/daelmaak/ngx-doe-gallery/blob/master/CHANGELOG.md)
+[**Changelog**](https://github.com/daelmaak/ngx-gallery/blob/master/CHANGELOG.md)
 
 
-## Why ngx-doe-gallery?
+## Why ngx-gallery?
 
-Because it gives you the doe eyes! Seriously though, use it if you need:
+Use it if you need:
 
 - Great performance and feel both on mobile and desktop
 - Very small size - gallery itself has just 9kB gzipped! It also packs no dependencies
@@ -68,7 +64,7 @@ that's it!
 In your ng module
 
 ```
-import { GalleryModule } from 'ngx-doe-gallery';
+import { GalleryModule } from '@daelmaak/ngx-gallery';
 
 @NgModule({
   imports: [ GalleryModule ]
@@ -79,7 +75,7 @@ import { GalleryModule } from 'ngx-doe-gallery';
 In your component
 
 ```
-import { GalleryImage } from 'ngx-doe-gallery';
+import { GalleryImage } from '@daelmaak/ngx-gallery';
 
 @Component({...})
 export class AppComponent {
@@ -90,7 +86,7 @@ export class AppComponent {
 In your component template
 
 ```
-<doe-gallery [items]="images"></doe-gallery>
+<gallery [items]="images"></gallery>
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Performant, responsive, easy to use Angular **8+** gallery
 [![npm](https://img.shields.io/npm/v/daelmaak/ngx-gallery.svg)](https://www.npmjs.com/package/daelmaak/ngx-gallery)
 
 [**Demos**](https://daelmaak.github.io/ngx-gallery/) |
-[**Docs**](https://github.com/daelmaak/ngx-gallery/wiki/Gallery-API/cc4f9ed153dd3362aef704cea5bc3eb4c3f34397) |
+[**Docs**](https://github.com/daelmaak/ngx-gallery/wiki) |
 [**Changelog**](https://github.com/daelmaak/ngx-gallery/blob/master/CHANGELOG.md)
 
 

--- a/angular.json
+++ b/angular.json
@@ -12,7 +12,7 @@
       },
       "root": "projects/gallery",
       "sourceRoot": "projects/gallery/src",
-      "prefix": "doe",
+      "prefix": "",
       "architect": {
         "build": {
           "builder": "@angular-devkit/build-angular:ng-packagr",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ngx-doe-gallery-demo",
-  "version": "0.1.0",
+  "name": "@daelmaak/ngx-gallery",
+  "version": "1.1.3",
   "license": "Apache-2.0",
   "author": {
     "name": "Daniel Macak",
@@ -14,7 +14,7 @@
     "start": "ng serve --host 0.0.0.0 demo",
     "serve": "http-server docs/",
     "build": "ng build",
-    "build:demo": "ng build --project=demo --base-href /ngx-doe-gallery/",
+    "build:demo": "ng build --project=demo --base-href /ngx-gallery/",
     "build:demo:local": "ng build --project=demo --base-href /",
     "test": "ng test --project=gallery --browsers=ChromeHeadlessLocal",
     "test:demo": "ng test --project=demo",

--- a/projects/demo/src/app/app.component.html
+++ b/projects/demo/src/app/app.component.html
@@ -25,7 +25,7 @@
   <div class="menu-heading">Misc</div>
   <ul>
     <li>
-      <a href="https://github.com/daelmaak/ngx-doe-gallery/wiki" target="_blank"
+      <a href="https://github.com/daelmaak/ngx-gallery/wiki" target="_blank"
         >Documentation</a
       >
     </li>
@@ -65,15 +65,15 @@
     <app-showcase
       id="demo-responsive"
       heading="Responsive - resize me!"
-      stackblitz="https://stackblitz.com/edit/ngx-doe-gallery-demo-responsive?file=src%2Fapp%2Fapp.component.html"
+      stackblitz="https://stackblitz.com/edit/ngx-gallery-demo-responsive?file=src%2Fapp%2Fapp.component.html"
     >
-      <doe-gallery [items]="images" loading="lazy"></doe-gallery>
+      <gallery [items]="images" loading="lazy"></gallery>
     </app-showcase>
 
     <app-showcase
       id="demo-multiple"
       heading="Multiple items"
-      stackblitz="https://stackblitz.com/edit/ngx-doe-gallery-demo-multiple-items?file=src%2Fapp%2Fapp.component.html"
+      stackblitz="https://stackblitz.com/edit/ngx-gallery-demo-multiple-items?file=src%2Fapp%2Fapp.component.html"
     >
       <app-demo-multiple-items
         [items]="smallerImages"
@@ -84,21 +84,21 @@
     <app-showcase
       id="demo-infinite-loop-multiple"
       heading="Infinite loop"
-      stackblitz="https://stackblitz.com/edit/ngx-doe-gallery-demo-infinite-loop?file=src%2Fapp%2Fapp.component.html"
+      stackblitz="https://stackblitz.com/edit/ngx-gallery-demo-infinite-loop?file=src%2Fapp%2Fapp.component.html"
     >
-      <doe-gallery
+      <gallery
         [items]="smallerImages"
         [loop]="true"
         loading="lazy"
         [itemWidth]="mobile ? '75%' : '34%'"
-      ></doe-gallery>
+      ></gallery>
     </app-showcase>
 
     <app-showcase
       id="demo-thumbs-orientation"
       heading="Thumbnails orientation & autoscroll"
       subheading="w/ infinite scroll"
-      stackblitz="https://stackblitz.com/edit/ngx-doe-gallery-demo-thumbs-orientation?file=src%2Fapp%2Fapp.component.html"
+      stackblitz="https://stackblitz.com/edit/ngx-gallery-demo-thumbs-orientation?file=src%2Fapp%2Fapp.component.html"
     >
       <app-demo-thumbs-orientation
         [items]="extendedImages"
@@ -107,23 +107,23 @@
     </app-showcase>
 
     <app-showcase id="demo-rtl" heading="Right to left">
-      <doe-gallery [items]="images" loading="lazy" [isRtl]="true"></doe-gallery>
+      <gallery [items]="images" loading="lazy" [isRtl]="true"></gallery>
     </app-showcase>
 
     <app-showcase
       id="demo-descriptions"
       heading="Descriptions"
-      stackblitz="https://stackblitz.com/edit/ngx-doe-gallery-demo-descriptions?file=src%2Fapp%2Fapp.component.html"
+      stackblitz="https://stackblitz.com/edit/ngx-gallery-demo-descriptions?file=src%2Fapp%2Fapp.component.html"
     >
-      <doe-gallery
+      <gallery
         [items]="images"
         [descriptions]="true"
         loading="lazy"
-      ></doe-gallery>
+      ></gallery>
     </app-showcase>
 
     <app-showcase id="demo-error-handling" heading="Error handling">
-      <doe-gallery [items]="erroredImages" loading="lazy"></doe-gallery>
+      <gallery [items]="erroredImages" loading="lazy"></gallery>
     </app-showcase>
 
     <app-showcase
@@ -131,25 +131,25 @@
       heading="Videos"
       subheading="both YouTube and native videos"
     >
-      <doe-gallery [items]="videos" loading="lazy"></doe-gallery>
+      <gallery [items]="videos" loading="lazy"></gallery>
     </app-showcase>
 
     <app-showcase
       id="demo-custom"
       heading="Custom items, arrows and error handling"
-      stackblitz="https://stackblitz.com/edit/ngx-doe-gallery-demo-custom-templates?file=src%2Fapp%2Fapp.component.html"
+      stackblitz="https://stackblitz.com/edit/ngx-gallery-demo-custom-templates?file=src%2Fapp%2Fapp.component.html"
     >
       <div subheading>
         You can also have custom loading screen, thumbnails, thumbnail errors
         and thumbnail navigation arrows. Find out how in the
         <a
-          href="https://github.com/daelmaak/ngx-doe-gallery/wiki/Gallery-API"
+          href="https://github.com/daelmaak/ngx-gallery/wiki/Gallery-API"
           target="_blank"
           >documentation</a
         >
         and/or try it out in
         <a
-          href="https://stackblitz.com/edit/ngx-doe-gallery-demo-custom-templates"
+          href="https://stackblitz.com/edit/ngx-gallery-demo-custom-templates"
           target="_blank"
           >StackBlitz</a
         >
@@ -163,13 +163,13 @@
         Some properties like custom templates are missing. Checkout them out in
         the
         <a
-          href="https://github.com/daelmaak/ngx-doe-gallery/wiki/Gallery-API"
+          href="https://github.com/daelmaak/ngx-gallery/wiki/Gallery-API"
           target="_blank"
           >documentation</a
         >
         and/or try them out in
         <a
-          href="https://stackblitz.com/edit/ngx-doe-gallery-demo-custom-templates"
+          href="https://stackblitz.com/edit/ngx-gallery-demo-custom-templates"
           target="_blank"
           >StackBlitz</a
         >

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { GalleryImage, GalleryVideo } from 'ngx-doe-gallery';
+import { GalleryImage, GalleryVideo } from '@daelmaak/ngx-gallery';
 
 @Component({
   selector: 'app-root',
@@ -9,11 +9,11 @@ import { GalleryImage, GalleryVideo } from 'ngx-doe-gallery';
 })
 export class AppComponent {
   installScript = `
-    npm i ngx-doe-gallery -S
+    npm i @daelmaak/ngx-gallery -S
   `;
 
   moduleCode = `
-    import { GalleryModule } from 'ngx-doe-gallery';
+    import { GalleryModule } from '@daelmaak/ngx-gallery';
 
     @NgModule({
       imports: [ GalleryModule ]
@@ -22,7 +22,7 @@ export class AppComponent {
   `;
 
   componentCode = `
-    import { GalleryImage } from 'ngx-doe-gallery';
+    import { GalleryImage } from '@daelmaak/ngx-gallery';
 
     @Component({...})
     export class AppComponent {
@@ -31,7 +31,7 @@ export class AppComponent {
   `;
 
   componentTemplateCode = `
-    <doe-gallery [items]="images"></doe-gallery>
+    <gallery [items]="images"></gallery>
   `;
 
   images = [

--- a/projects/demo/src/app/app.module.ts
+++ b/projects/demo/src/app/app.module.ts
@@ -18,7 +18,7 @@ import { ShowcaseComponent } from './components/showcase/showcase.component';
 import { DemoThumbsOrientationComponent } from './components/demo-thumbs-orientation/demo-thumbs-orientation.component';
 import { DemoMultipleItemsComponent } from './components/demo-multiple-items/demo-multiple-items.component';
 import { DemoCustomTemplatesComponent } from './components/demo-custom-templates/demo-custom-templates.component';
-import { GalleryModule } from 'ngx-doe-gallery';
+import { GalleryModule } from '@daelmaak/ngx-gallery';
 
 const materialModules = [
   MatButtonModule,

--- a/projects/demo/src/app/components/demo-custom-templates/demo-custom-templates.component.html
+++ b/projects/demo/src/app/components/demo-custom-templates/demo-custom-templates.component.html
@@ -1,16 +1,16 @@
-<doe-gallery
+<gallery
   [items]="images"
   [itemTemplate]="customItem"
   [arrowTemplate]="customArrow"
   [errorTemplate]="customError"
   loading="lazy"
-></doe-gallery>
+></gallery>
 
 <ng-template #customItem let-item="item" let-video="video">
   <div class="custom-item">
     <div class="image-container">
-      <img *ngIf="!video" [src]="item.src" doeMedia />
-      <video *ngIf="video" [src]="item.src" controls doeMedia></video>
+      <img *ngIf="!video" [src]="item.src" media />
+      <video *ngIf="video" [src]="item.src" controls media></video>
     </div>
     <p class="description">{{ item.description }}</p>
   </div>

--- a/projects/demo/src/app/components/demo-custom-templates/demo-custom-templates.component.ts
+++ b/projects/demo/src/app/components/demo-custom-templates/demo-custom-templates.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { GalleryImage, GalleryVideo } from 'ngx-doe-gallery';
+import { GalleryImage, GalleryVideo } from '@daelmaak/ngx-gallery';
 
 @Component({
   selector: 'app-demo-custom-templates',

--- a/projects/demo/src/app/components/demo-multiple-items/demo-multiple-items.component.html
+++ b/projects/demo/src/app/components/demo-multiple-items/demo-multiple-items.component.html
@@ -8,9 +8,9 @@
   />
 </mat-form-field>
 
-<doe-gallery
+<gallery
   *ngIf="showGallery"
   [items]="items"
   [itemWidth]="itemWidth"
   loading="lazy"
-></doe-gallery>
+></gallery>

--- a/projects/demo/src/app/components/demo-multiple-items/demo-multiple-items.component.ts
+++ b/projects/demo/src/app/components/demo-multiple-items/demo-multiple-items.component.ts
@@ -6,7 +6,7 @@ import {
   OnChanges,
   SimpleChanges,
 } from '@angular/core';
-import { GalleryItem } from 'ngx-doe-gallery';
+import { GalleryItem } from '@daelmaak/ngx-gallery';
 
 @Component({
   selector: 'app-demo-multiple-items',

--- a/projects/demo/src/app/components/demo-thumbs-orientation/demo-thumbs-orientation.component.html
+++ b/projects/demo/src/app/components/demo-thumbs-orientation/demo-thumbs-orientation.component.html
@@ -5,10 +5,10 @@
   <mat-radio-button value="right">right</mat-radio-button>
 </mat-radio-group>
 
-<doe-gallery
+<gallery
   #gallery
   [items]="items"
   loading="lazy"
   [loop]="true"
   [thumbsOrientation]="orientation"
-></doe-gallery>
+></gallery>

--- a/projects/demo/src/app/components/demo-thumbs-orientation/demo-thumbs-orientation.component.ts
+++ b/projects/demo/src/app/components/demo-thumbs-orientation/demo-thumbs-orientation.component.ts
@@ -5,7 +5,7 @@ import {
   OnChanges,
   SimpleChanges,
 } from '@angular/core';
-import { GalleryItem, Orientation } from 'ngx-doe-gallery';
+import { GalleryItem, Orientation } from '@daelmaak/ngx-gallery';
 
 @Component({
   selector: 'app-demo-thumbs-orientation',

--- a/projects/demo/src/app/components/demo-whole-config/demo-whole-config.component.html
+++ b/projects/demo/src/app/components/demo-whole-config/demo-whole-config.component.html
@@ -193,7 +193,7 @@
 </form>
 
 <div class="gallery-container">
-  <doe-gallery
+  <gallery
     *ngIf="displayGallery"
     [items]="items | async"
     [selectedIndex]="+galleryConfig.selectedIndex"
@@ -216,7 +216,7 @@
     [thumbsScrollBehavior]="galleryConfig.thumbsScrollBehavior"
     (imageClick)="onImageClick($event)"
     (descriptionClick)="galleryConfig.descriptions = false"
-  ></doe-gallery>
+  ></gallery>
 </div>
 
 <ng-template #loadingTemplate>

--- a/projects/demo/src/app/components/demo-whole-config/demo-whole-config.component.scss
+++ b/projects/demo/src/app/components/demo-whole-config/demo-whole-config.component.scss
@@ -56,7 +56,7 @@ mat-form-field {
   height: calc(100vh - 64px);
 }
 
-doe-gallery {
+gallery {
   width: 100%;
   height: 95%;
   margin: 0 auto;

--- a/projects/demo/src/app/components/demo-whole-config/demo-whole-config.component.spec.ts
+++ b/projects/demo/src/app/components/demo-whole-config/demo-whole-config.component.spec.ts
@@ -8,7 +8,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatIconModule } from '@angular/material/icon';
 
 import { DemoWholeConfigComponent } from './demo-whole-config.component';
-import { GalleryModule } from 'ngx-doe-gallery';
+import { GalleryModule } from '@daelmaak/ngx-gallery';
 
 describe('DemoWholeConfigComponent', () => {
   let component: DemoWholeConfigComponent;

--- a/projects/demo/src/app/components/demo-whole-config/demo-whole-config.component.ts
+++ b/projects/demo/src/app/components/demo-whole-config/demo-whole-config.component.ts
@@ -1,8 +1,8 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit, ViewChild } from '@angular/core';
 import { defer, Observable, of } from 'rxjs';
 import { delay, switchMap } from 'rxjs/operators';
-import { GalleryComponent, GalleryItem, GalleryItemEvent } from 'ngx-doe-gallery';
-import { GalleryItemInternal } from 'ngx-doe-gallery/lib/core/gallery-item';
+import { GalleryComponent, GalleryItem, GalleryItemEvent } from '@daelmaak/ngx-gallery';
+import { GalleryItemInternal } from '@daelmaak/ngx-gallery/lib/core/gallery-item';
 
 @Component({
   selector: 'app-demo-whole-config',

--- a/projects/demo/src/app/components/header/header.component.html
+++ b/projects/demo/src/app/components/header/header.component.html
@@ -1,23 +1,20 @@
 <header>
   <div class="header-inner-container">
     <div>
-      <img class="logo" src="./assets/icons/doe.png" alt="logo" />
-    </div>
-    <div>
-      <h1>Ngx Doe Gallery</h1>
+      <h1>Ngx Gallery</h1>
       <div class="subtitle">
         Performant, mobile first, easy to use Angular 8+ Gallery
       </div>
 
       <div class="links">
         <a
-          href="https://github.com/daelmaak/ngx-doe-gallery"
+          href="https://github.com/daelmaak/ngx-gallery"
           class="github-link link"
         >
           <img src="./assets/icons/GitHub-Mark-64px.png" alt="github link" />
         </a>
         <a
-          href="https://www.npmjs.com/package/ngx-doe-gallery"
+          href="https://www.npmjs.com/package/ngx-gallery"
           class="npm-link link"
           rel="noreferrer"
         >

--- a/projects/demo/src/app/components/showcase/showcase.component.scss
+++ b/projects/demo/src/app/components/showcase/showcase.component.scss
@@ -6,7 +6,7 @@
     margin: 0 auto;
   }
 
-  ::ng-deep doe-gallery {
+  ::ng-deep gallery {
     width: 100%;
     background-color: #f3f3f3;
   }

--- a/projects/demo/src/index.html
+++ b/projects/demo/src/index.html
@@ -2,11 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Ngx Doe Gallery</title>
+    <title>Ngx Gallery</title>
     <base href="/" />
     <meta name="description" content="Angular Gallery/Carousel component" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" type="image/x-icon" href="assets/icons/doe.ico" />
     <link
       href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet"

--- a/projects/gallery/package.json
+++ b/projects/gallery/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ngx-doe-gallery",
+  "name": "@daelmaak/ngx-gallery",
   "version": "1.1.3",
   "license": "Apache-2.0",
   "author": {
@@ -7,10 +7,10 @@
     "email": "daniel.macak@email.cz",
     "url": "https://github.com/daelmaak"
   },
-  "homepage": "https://daelmaak.github.io/ngx-doe-gallery/",
+  "homepage": "https://daelmaak.github.io/ngx-gallery/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/daelmaak/ngx-doe-gallery.git"
+    "url": "https://github.com/daelmaak/ngx-gallery.git"
   },
   "keywords": [
     "gallery",

--- a/projects/gallery/src/lib/components/counter/counter.component.scss
+++ b/projects/gallery/src/lib/components/counter/counter.component.scss
@@ -18,6 +18,6 @@
   }
 }
 
-.doe-counter-delimiter {
+.counter-delimiter {
   padding: 0 2px;
 }

--- a/projects/gallery/src/lib/components/counter/counter.component.ts
+++ b/projects/gallery/src/lib/components/counter/counter.component.ts
@@ -8,10 +8,10 @@ import {
 import { VerticalOrientation } from '../../core';
 
 @Component({
-  selector: 'doe-counter',
+  selector: 'counter',
   template: `
     <span aria-hidden="true">
-      {{ selectedIndex + 1 }}<span class="doe-counter-delimiter">/</span
+      {{ selectedIndex + 1 }}<span class="counter-delimiter">/</span
       >{{ itemQuantity || 0 }}
     </span>
   `,

--- a/projects/gallery/src/lib/components/gallery/gallery.component.html
+++ b/projects/gallery/src/lib/components/gallery/gallery.component.html
@@ -1,8 +1,8 @@
-<span *ngIf="aria?.galleryLabel" class="doe-sr-only" tabindex="0">
+<span *ngIf="aria?.galleryLabel" class="sr-only" tabindex="0">
   {{ aria.galleryLabel }}
 </span>
 
-<doe-thumbs
+<thumbs
   *ngIf="thumbs"
   [items]="items"
   [selectedIndex]="selectedIndex"
@@ -18,9 +18,9 @@
   [isRtl]="isRtl"
   (thumbClick)="_onThumbClick($event)"
   (thumbHover)="thumbHover.emit($event)"
-></doe-thumbs>
+></thumbs>
 
-<doe-viewer
+<viewer
   [items]="items"
   [selectedIndex]="selectedIndex"
   [arrows]="arrows"
@@ -47,10 +47,10 @@
   (descriptionClick)="descriptionClick.emit($event)"
   (selection)="_selectInternal($event); _thumbsRef?.select($event)"
 >
-</doe-viewer>
+</viewer>
 
 <ng-template #defaultLoadingTemplate>
-  <div class="doe-loading">
+  <div class="loading">
     <div></div>
     <div></div>
     <div></div>

--- a/projects/gallery/src/lib/components/gallery/gallery.component.scss
+++ b/projects/gallery/src/lib/components/gallery/gallery.component.scss
@@ -5,16 +5,16 @@
   outline: 0;
   position: relative;
 
-  &.doe-gallery--column {
+  &.gallery--column {
     flex-direction: column;
   }
 
   &.rtl {
-    // maintains doe-thumbs orientation also when the whole document is in RTL mode
+    // maintains thumbs orientation also when the whole document is in RTL mode
     direction: ltr;
 
-    doe-viewer,
-    doe-thumbs {
+    viewer,
+    thumbs {
       direction: rtl;
     }
   }
@@ -33,7 +33,7 @@
     padding: 0;
   }
 
-  .doe-sr-only {
+  .sr-only {
     position: absolute !important;
     clip: rect(1px, 1px, 1px, 1px);
     top: auto;
@@ -44,7 +44,7 @@
   }
 }
 
-.doe-loading {
+.loading {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -62,7 +62,7 @@
     background-color: #4a4a4a;
     animation: bounce 2s infinite;
     border-radius: 50%;
-    box-shadow: 0 0 0px 1px whitesmoke, 0 0 1px 1px whitesmoke;
+    box-shadow: 0 0 0 1px whitesmoke, 0 0 1px 1px whitesmoke;
 
     + div {
       margin-left: 10px;

--- a/projects/gallery/src/lib/components/gallery/gallery.component.spec.ts
+++ b/projects/gallery/src/lib/components/gallery/gallery.component.spec.ts
@@ -55,7 +55,7 @@ describe('GalleryComponent', () => {
 
     it('should emit event when viewer image clicked', () => {
       const imageClickSpy = spyOn(component.imageClick, 'emit');
-      const secondItem = de.queryAll(By.css('doe-viewer ul li'))[1];
+      const secondItem = de.queryAll(By.css('viewer ul li'))[1];
 
       const mockedClick = { name: 'mocked-event' } as any;
       secondItem.triggerEventHandler('click', mockedClick);
@@ -70,7 +70,7 @@ describe('GalleryComponent', () => {
 
     it('should emit event when thumbnail clicked', () => {
       const thumbClickSpy = spyOn(component.thumbClick, 'emit');
-      const secondThumb = de.queryAll(By.css('doe-thumbs ul li'))[1];
+      const secondThumb = de.queryAll(By.css('thumbs ul li'))[1];
 
       const mockedClick = { name: 'mocked-event' } as any;
       secondThumb.triggerEventHandler('click', mockedClick);
@@ -85,7 +85,7 @@ describe('GalleryComponent', () => {
 
     it('should emit event when thumbnail hovered', () => {
       const thumbHoverSpy = spyOn(component.thumbHover, 'emit');
-      const secondThumb = de.queryAll(By.css('doe-thumbs ul li'))[1];
+      const secondThumb = de.queryAll(By.css('thumbs ul li'))[1];
 
       const mockedMouseenter = { name: 'mocked-event' } as any;
       secondThumb.triggerEventHandler('mouseenter', mockedMouseenter);

--- a/projects/gallery/src/lib/components/gallery/gallery.component.ts
+++ b/projects/gallery/src/lib/components/gallery/gallery.component.ts
@@ -29,7 +29,7 @@ import { ThumbsComponent } from '../thumbs/thumbs.component';
 import { ViewerComponent } from '../viewer/viewer.component';
 
 @Component({
-  selector: 'doe-gallery',
+  selector: 'gallery',
   templateUrl: './gallery.component.html',
   styleUrls: ['./gallery.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -81,7 +81,7 @@ export class GalleryComponent {
   _touched = false;
   INIT_INTERACTIONS = ['touchstart', 'mousedown', 'keydown'];
 
-  @HostBinding('class.doe-gallery--column')
+  @HostBinding('class.gallery--column')
   get _galleryColumn() {
     return (
       this.thumbsOrientation === 'top' || this.thumbsOrientation === 'bottom'

--- a/projects/gallery/src/lib/components/icons/chevron/chevron-icon.component.ts
+++ b/projects/gallery/src/lib/components/icons/chevron/chevron-icon.component.ts
@@ -1,7 +1,7 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 
 @Component({
-  selector: 'doe-chevron-icon',
+  selector: 'chevron-icon',
   templateUrl: './chevron-icon.component.html',
   styleUrls: ['./chevron-icon.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/projects/gallery/src/lib/components/thumbs/thumbs.component.html
+++ b/projects/gallery/src/lib/components/thumbs/thumbs.component.html
@@ -1,19 +1,19 @@
 <div
   *ngIf="showStartArrow"
-  class="doe-thumbs-arrow doe-thumbs-arrow-prev"
+  class="thumbs-arrow thumbs-arrow-prev"
   (click)="slide(-1)"
 >
   <div *ngIf="!arrowTemplate; else arrowTemplate">
-    <doe-chevron-icon></doe-chevron-icon>
+    <chevron-icon></chevron-icon>
   </div>
 </div>
 
 <ul #thumbs [style.scrollBehavior]="scrollBehavior" [class.rtl]="isRtl">
-  <li *ngIf="!items || !items.length" class="doe-thumbs-initial-item"></li>
+  <li *ngIf="!items || !items.length" class="thumbs-initial-item"></li>
   <li
     #thumb
     *ngFor="let item of items; let i = index"
-    [class.doe-thumbs-item--selected]="i === selectedIndex"
+    [class.thumbs-item--selected]="i === selectedIndex"
     aria-hidden="true"
     (click)="emitEvent(i, item, $event, thumbClick)"
     (mouseenter)="emitEvent(i, item, $event, thumbHover)"
@@ -29,11 +29,11 @@
       <ng-container *ngIf="item._thumbFailed">
         <div
           *ngIf="!errorTemplate; else errorTemplate"
-          class="doe-thumbs-error"
+          class="thumbs-error"
         >
           <div
-            class="doe-thumbs-error-icon"
-            [class.doe-thumbs-error-icon--video]="isVideo(item)"
+            class="thumbs-error-icon"
+            [class.thumbs-error-icon--video]="isVideo(item)"
           ></div>
         </div>
       </ng-container>
@@ -52,10 +52,10 @@
 
 <div
   *ngIf="showEndArrow"
-  class="doe-thumbs-arrow doe-thumbs-arrow-next"
+  class="thumbs-arrow thumbs-arrow-next"
   (click)="slide(1)"
 >
   <div *ngIf="!arrowTemplate; else arrowTemplate">
-    <doe-chevron-icon></doe-chevron-icon>
+    <chevron-icon></chevron-icon>
   </div>
 </div>

--- a/projects/gallery/src/lib/components/thumbs/thumbs.component.scss
+++ b/projects/gallery/src/lib/components/thumbs/thumbs.component.scss
@@ -8,7 +8,7 @@ $arrow-btn-dimension: 30px;
   background-color: #f3f3f3;
 }
 
-:host.doe-thumbs {
+:host.thumbs {
   &--top,
   &--bottom {
     width: 100%;
@@ -48,7 +48,7 @@ $arrow-btn-dimension: 30px;
       }
     }
 
-    .doe-thumbs-arrow {
+    .thumbs-arrow {
       top: 0;
       height: 100%;
 
@@ -66,7 +66,7 @@ $arrow-btn-dimension: 30px;
       }
     }
 
-    .doe-thumbs-error {
+    .thumbs-error {
       border-right: 1px solid #cecece;
     }
   }
@@ -85,7 +85,7 @@ $arrow-btn-dimension: 30px;
       border-top: 0;
     }
 
-    .doe-thumbs-arrow {
+    .thumbs-arrow {
       width: 100%;
 
       > div {
@@ -93,7 +93,7 @@ $arrow-btn-dimension: 30px;
         height: $arrow-btn-dimension;
       }
 
-      doe-chevron-icon {
+      chevron-icon {
         transform: rotate(90deg);
       }
 
@@ -106,7 +106,7 @@ $arrow-btn-dimension: 30px;
       }
     }
 
-    .doe-thumbs-error {
+    .thumbs-error {
       border-bottom: 1px solid #cecece;
     }
   }
@@ -143,11 +143,11 @@ li {
   position: relative;
   cursor: pointer;
 
-  &.doe-thumbs-initial-item {
+  &.thumbs-initial-item {
     visibility: hidden;
   }
 
-  &.doe-thumbs-item--selected {
+  &.thumbs-item--selected {
     &::after {
       content: '';
       display: block;
@@ -171,7 +171,7 @@ img {
   color: transparent;
 }
 
-.doe-thumbs-error {
+.thumbs-error {
   position: absolute;
   left: 0;
   top: 0;
@@ -225,7 +225,7 @@ img {
   }
 }
 
-.doe-thumbs-arrow {
+.thumbs-arrow {
   position: absolute;
   cursor: pointer;
   z-index: 10;

--- a/projects/gallery/src/lib/components/thumbs/thumbs.component.spec.ts
+++ b/projects/gallery/src/lib/components/thumbs/thumbs.component.spec.ts
@@ -61,9 +61,9 @@ describe('ThumbnailsComponent', () => {
 
       const itemEls = de.queryAll(By.css('li'));
 
-      expect(itemEls[0].classes['doe-thumbs-item--selected']).toBeFalsy();
-      expect(itemEls[1].classes['doe-thumbs-item--selected']).toBeTruthy();
-      expect(itemEls[2].classes['doe-thumbs-item--selected']).toBeFalsy();
+      expect(itemEls[0].classes['thumbs-item--selected']).toBeFalsy();
+      expect(itemEls[1].classes['thumbs-item--selected']).toBeTruthy();
+      expect(itemEls[2].classes['thumbs-item--selected']).toBeFalsy();
     });
   });
 
@@ -120,7 +120,7 @@ describe('ThumbnailsComponent', () => {
       });
 
       function getChevron(chevronContainer: DebugElement) {
-        return chevronContainer.query(By.css('doe-chevron-icon'))
+        return chevronContainer.query(By.css('chevron-icon'))
           .nativeElement as HTMLElement;
       }
     });
@@ -300,7 +300,7 @@ describe('ThumbnailsComponent', () => {
         waitForArrows(done, _ => {
           toggleArrows(false);
 
-          const arrows = de.queryAll(By.css('doe-chevron-icon'));
+          const arrows = de.queryAll(By.css('chevron-icon'));
           expect(arrows.length).toBe(0);
         });
       });
@@ -327,7 +327,7 @@ describe('ThumbnailsComponent', () => {
           fixture.detectChanges();
           flush();
 
-          const arrows = de.queryAll(By.css('doe-chevron-icon'));
+          const arrows = de.queryAll(By.css('chevron-icon'));
           expect(arrows.length).toBe(0);
         }));
 
@@ -495,11 +495,11 @@ describe('ThumbnailsComponent', () => {
     });
 
     function isPrevArrow(arrow: DebugElement) {
-      return arrow.attributes.class.includes('doe-thumbs-arrow-prev');
+      return arrow.attributes.class.includes('thumbs-arrow-prev');
     }
 
     function isNextArrow(arrow: DebugElement) {
-      return arrow.attributes.class.includes('doe-thumbs-arrow-next');
+      return arrow.attributes.class.includes('thumbs-arrow-next');
     }
 
     function toggleArrows(enabled: boolean) {
@@ -552,7 +552,7 @@ describe('ThumbnailsComponent', () => {
       let arrows: DebugElement[];
 
       const arrowWaiter = setInterval(i => {
-        arrows = de.queryAll(By.css('doe-chevron-icon'));
+        arrows = de.queryAll(By.css('chevron-icon'));
 
         if (arrows.length) {
           clearInterval(arrowWaiter);
@@ -566,7 +566,7 @@ describe('ThumbnailsComponent', () => {
     let arrows: DebugElement[];
 
     const arrowWaiter = setInterval(() => {
-      arrows = de.queryAll(By.css('.doe-thumbs-arrow'));
+      arrows = de.queryAll(By.css('.thumbs-arrow'));
 
       if (arrows.length) {
         clearInterval(arrowWaiter);

--- a/projects/gallery/src/lib/components/thumbs/thumbs.component.ts
+++ b/projects/gallery/src/lib/components/thumbs/thumbs.component.ts
@@ -29,7 +29,7 @@ import {
 } from '../../core/gallery-item';
 
 @Component({
-  selector: 'doe-thumbs',
+  selector: 'thumbs',
   templateUrl: './thumbs.component.html',
   styleUrls: ['./thumbs.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -64,7 +64,7 @@ export class ThumbsComponent implements OnChanges, OnDestroy {
 
   @HostBinding('class')
   get cssClass() {
-    return `doe-thumbs--${this.orientation}`;
+    return `thumbs--${this.orientation}`;
   }
 
   private get hostOffsetAxis(): number {

--- a/projects/gallery/src/lib/components/viewer/viewer.component.html
+++ b/projects/gallery/src/lib/components/viewer/viewer.component.html
@@ -1,25 +1,25 @@
 <div
   *ngIf="showPrevArrow"
-  class="doe-viewer-arrow doe-viewer-arrow-prev"
+  class="viewer-arrow viewer-arrow-prev"
   (click)="selectByDelta(-1)"
 >
-  <doe-chevron-icon
+  <chevron-icon
     *ngIf="!arrowTemplate; else arrowTemplate"
-  ></doe-chevron-icon>
+  ></chevron-icon>
 </div>
 
 <ul #itemList [attr.aria-label]="aria?.viewerLabel">
-  <li *ngIf="!_displayedItems?.length" class="doe-viewer-initial-item"></li>
+  <li *ngIf="!_displayedItems?.length" class="viewer-initial-item"></li>
   <li
     #itemsRef
     *ngFor="let item of _displayedItems; let i = index"
-    [class.doe-viewer-item--selected]="i === selectedIndex"
+    [class.viewer-item--selected]="i === selectedIndex"
     [attr.tabindex]="itemTabbable(i)"
     [attr.aria-label]="item.alt"
-    [attr.aria-describedby]="'doe-viewer-aria-description-' + i"
+    [attr.aria-describedby]="'viewer-aria-description-' + i"
     (click)="onImageClick(item, $event)"
-    (doe-media-load)="onItemLoaded(item)"
-    (doe-media-error)="onItemErrored(item)"
+    (media-load)="onItemLoaded(item)"
+    (media-error)="onItemErrored(item)"
     (keydown.Tab)="onTab(i + 1)"
     (keydown.shift.Tab)="onTab(i - 1)"
   >
@@ -36,7 +36,7 @@
           <img
             [src]="item.src"
             [alt]="item.alt"
-            [class.doe-viewer-media-loading]="!itemLoaded(item)"
+            [class.viewer-media-loading]="!itemLoaded(item)"
             [style.objectFit]="objectFit"
             (load)="onItemLoaded(item)"
             (error)="onItemErrored(item)"
@@ -48,7 +48,7 @@
           @mediaAnimate
           [src]="item.src"
           [poster]="item.thumbSrc || ''"
-          [class.doe-viewer-media-loading]="!itemLoaded(item)"
+          [class.viewer-media-loading]="!itemLoaded(item)"
           [style.objectFit]="objectFit"
           controls
           playsinline
@@ -74,18 +74,18 @@
       <ng-container *ngIf="itemFailedToLoad(item)">
         <div
           *ngIf="!errorTemplate; else errorTemplate"
-          class="doe-viewer-error"
+          class="viewer-error"
         >
-          <div class="doe-viewer-error-icon">⚠</div>
-          <p class="doe-viewer-error-text">
+          <div class="viewer-error-icon">⚠</div>
+          <p class="viewer-error-text">
             {{ errorText || 'Loading of this media failed' }}
           </p>
         </div>
       </ng-container>
 
       <span
-        [id]="'doe-viewer-aria-description-' + i"
-        class="doe-sr-only"
+        [id]="'viewer-aria-description-' + i"
+        class="sr-only"
         [innerHTML]="item.description"
       ></span>
     </ng-container>
@@ -112,20 +112,20 @@
 
 <div
   *ngIf="showNextArrow"
-  class="doe-viewer-arrow doe-viewer-arrow-next"
+  class="viewer-arrow viewer-arrow-next"
   (click)="selectByDelta(1)"
 >
-  <doe-chevron-icon
+  <chevron-icon
     *ngIf="!arrowTemplate; else arrowTemplate"
-  ></doe-chevron-icon>
+  ></chevron-icon>
 </div>
 
-<doe-counter
+<counter
   *ngIf="counter && items?.length"
   [itemQuantity]="items?.length"
   [selectedIndex]="selectedIndex"
   [orientation]="counterOrientation"
-></doe-counter>
+></counter>
 
 <ng-container
   *ngTemplateOutlet="
@@ -138,15 +138,15 @@
 
 <div
   *ngIf="descriptions && items"
-  class="doe-viewer-description"
-  [class.doe-viewer-description--above-counter]="
+  class="viewer-description"
+  [class.viewer-description--above-counter]="
     counter && counterOrientation === 'bottom'
   "
   aria-hidden="true"
 >
   <div
     *ngIf="items[selectedIndex]?.description as description"
-    class="doe-viewer-description-inner"
+    class="viewer-description-inner"
     [innerHTML]="description"
     (click)="descriptionClick.emit($event)"
   ></div>

--- a/projects/gallery/src/lib/components/viewer/viewer.component.scss
+++ b/projects/gallery/src/lib/components/viewer/viewer.component.scss
@@ -17,13 +17,13 @@ $default-item-width: calc(100% - 0.01px);
   z-index: 1;
 
   &.rtl {
-    .doe-viewer-arrow-next {
+    .viewer-arrow-next {
       right: auto;
       left: 0;
       transform: translateY(-50%) scale(-1);
     }
 
-    .doe-viewer-arrow-prev {
+    .viewer-arrow-prev {
       right: 0;
       left: auto;
       transform: translateY(-50%);
@@ -86,7 +86,7 @@ img {
   user-select: none;
 }
 
-.doe-viewer-description {
+.viewer-description {
   position: absolute;
   bottom: 5px;
   width: 100%;
@@ -109,7 +109,7 @@ img {
   }
 }
 
-.doe-viewer-error {
+.viewer-error {
   position: absolute;
   left: 0;
   top: 0;
@@ -132,7 +132,7 @@ img {
   }
 }
 
-.doe-viewer-arrow {
+.viewer-arrow {
   display: flex;
   position: absolute;
   top: 50%;
@@ -149,7 +149,7 @@ img {
     right: 0;
   }
 
-  doe-chevron-icon {
+  chevron-icon {
     $icon-dimension: 32px;
 
     margin: 15px 6px;

--- a/projects/gallery/src/lib/components/viewer/viewer.component.spec.ts
+++ b/projects/gallery/src/lib/components/viewer/viewer.component.spec.ts
@@ -71,7 +71,7 @@ describe('ViewerComponent', () => {
 
       expect(component).toBeTruthy();
 
-      expect(de.query(By.css('.doe-viewer-initial-item'))).toBeTruthy();
+      expect(de.query(By.css('.viewer-initial-item'))).toBeTruthy();
     });
 
     it('should display items even though they have been set later', fakeAsync(() => {
@@ -93,7 +93,7 @@ describe('ViewerComponent', () => {
       flush();
 
       expect(
-        de.queryAll(By.css('li:not(.doe-viewer-initial-item)')).length
+        de.queryAll(By.css('li:not(.viewer-initial-item)')).length
       ).toBe(2);
     }));
 
@@ -109,7 +109,7 @@ describe('ViewerComponent', () => {
       tick();
 
       expect(
-        de.queryAll(By.css('li'))[1].classes['doe-viewer-item--selected']
+        de.queryAll(By.css('li'))[1].classes['viewer-item--selected']
       ).toBeTruthy();
       expect(de.query(By.css('ul')).nativeElement.style.transform).toMatch(
         /translate3d\(-\d+px, 0px, 0px\)/
@@ -360,9 +360,9 @@ describe('ViewerComponent', () => {
       component.ngOnChanges(changes);
       fixture.detectChanges();
 
-      const descContainer = de.query(By.css('.doe-viewer-description'));
+      const descContainer = de.query(By.css('.viewer-description'));
       expect(
-        descContainer.classes['doe-viewer-description--above-counter']
+        descContainer.classes['viewer-description--above-counter']
       ).toBeFalsy();
     });
   });

--- a/projects/gallery/src/lib/components/viewer/viewer.component.ts
+++ b/projects/gallery/src/lib/components/viewer/viewer.component.ts
@@ -39,7 +39,7 @@ const passiveEventListenerOpts = {
 };
 
 @Component({
-  selector: 'doe-viewer',
+  selector: 'viewer',
   templateUrl: './viewer.component.html',
   styleUrls: ['./viewer.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/gallery/src/lib/directives/media.directive.ts
+++ b/projects/gallery/src/lib/directives/media.directive.ts
@@ -1,7 +1,7 @@
 import { Directive, ElementRef, HostListener } from '@angular/core';
 
 @Directive({
-  selector: '[doeMedia]',
+  selector: '[media]',
 })
 export class MediaDirective {
   constructor(private hostRef: ElementRef<HTMLElement>) {}
@@ -10,7 +10,7 @@ export class MediaDirective {
   @HostListener('loadedmetadata', ['$event'])
   @HostListener('error', ['$event'])
   onLoad(ev: Event) {
-    const evName = ev.type === 'error' ? 'doe-media-error' : 'doe-media-load';
+    const evName = ev.type === 'error' ? 'media-error' : 'media-load';
 
     this.hostRef.nativeElement.dispatchEvent(new CustomEvent(evName, {
       bubbles: true,

--- a/projects/gallery/src/public-api.ts
+++ b/projects/gallery/src/public-api.ts
@@ -1,5 +1,5 @@
 /*
- * Public API Surface of doe-gallery
+ * Public API Surface of the gallery
  */
 export * from './lib/components/gallery/gallery.component';
 export * from './lib/gallery.module';

--- a/projects/gallery/tslint.json
+++ b/projects/gallery/tslint.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tslint.json",
   "rules": {
-    "directive-selector": [true, "attribute", "doe", "camelCase"],
-    "component-selector": [true, "element", "doe", "kebab-case"],
+    "directive-selector": [true, "attribute", "", "camelCase"],
     "no-string-literal": false
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,8 @@
     "typeRoots": ["node_modules/@types"],
     "lib": ["es2018", "dom"],
     "paths": {
-      "ngx-doe-gallery": ["projects/gallery/src/public-api.ts"],
-      "ngx-doe-gallery/*": ["projects/gallery/src/*"]
+      "@daelmaak/ngx-gallery": ["projects/gallery/src/public-api.ts"],
+      "@daelmaak/ngx-gallery/*": ["projects/gallery/src/*"],
     }
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
Reasons:
1. Better visibility in search (so I hope)
2. Smaller string sizes everywhere, since the names change from doe-gallery to just gallery. The same for doe-thumbs, doe-viewer and so on.

Before merging this, I should wait for:
- Migrating build from circle ci to GH actions. I'd rather have everything "in-house" for the name changing, to prevent potential issues.
- Migration to Jest. Current karma+jasmine setup is not very portable, at least not on WSL. One has to download and setup chrome on WSL first in order to be able to run tests, which sucks.

Also, since my plan is to connect the name change to a new major - 2, I should probably wait for:
- Angular upgrade. To be decided to which version. I shall check which ng versions are LTS.
- Removal of IE11 support. Finally!