### PR TITLE
feat: improve infinte loop

### DIFF
--- a/libs/gallery/src/lib/components/viewer/viewer.component.html
+++ b/libs/gallery/src/lib/components/viewer/viewer.component.html
@@ -2,6 +2,7 @@
   *ngIf="showPrevArrow"
   aria-label="Previous image"
   class="viewer-arrow viewer-arrow-prev"
+  (mousedown)="$event.stopPropagation()"
   (click)="selectByDelta(-1)"
 >
   <chevron-icon *ngIf="!arrowTemplate; else arrowTemplate"></chevron-icon>
@@ -105,6 +106,7 @@
   *ngIf="showNextArrow"
   aria-label="Next image"
   class="viewer-arrow viewer-arrow-next"
+  (mousedown)="$event.stopPropagation()"
   (click)="selectByDelta(1)"
 >
   <chevron-icon *ngIf="!arrowTemplate; else arrowTemplate"></chevron-icon>


### PR DESCRIPTION
The motivation for this is to simplify the looping mechanism by using
native api instead of faking fringe items in extensive amount. All this
to prepare for a move into a more general slider direction than just
image gallery.

Ideally, I'd use only the IntersectionObserver for the looping exclusively
but it is not practical. The problem is the selection with
IntersectionObserver is very much timing dependent, based on the animation
that at some point reveals fringe item and loops. Interference with user
swiping is unavoidable and handling conflicts between these would require
Web Animation API with its stopping capability. This is too complicated so
I resolved to keep control - use Inter Obs only for swiping, and the old
pointer-based mechanism for the rest of the looping scenarios. Doing this
removes the dependency on animation timing and instead bases the looping
solely on the pointer position, which is very much desired since it's
deterministic.

This commit also fixes a bug in the looping which didn't work correctly
when using arrows for looping.
