### PR TITLE
fix: make `items` always defined

### DIFF
--- a/libs/gallery/src/lib/components/gallery/gallery.component.spec.ts
+++ b/libs/gallery/src/lib/components/gallery/gallery.component.spec.ts
@@ -1,16 +1,18 @@
 import { DebugElement } from '@angular/core';
 import {
   ComponentFixture,
-  fakeAsync,
   TestBed,
+  fakeAsync,
   tick,
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import type { StrictComponentRef } from '../../core/ng';
 import { GalleryComponent } from './gallery.component';
 
 describe('GalleryComponent', () => {
   let component: GalleryComponent;
+  let componentRef: StrictComponentRef<GalleryComponent>;
   let fixture: ComponentFixture<GalleryComponent>;
   let de: DebugElement;
 
@@ -23,12 +25,21 @@ describe('GalleryComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(GalleryComponent);
     component = fixture.componentInstance;
+    componentRef = fixture.componentRef;
     de = fixture.debugElement;
   });
 
   it('should create', () => {
     fixture.detectChanges();
     expect(component).toBeTruthy();
+  });
+
+  it('should handle empty items input in looping mode', () => {
+    componentRef.setInput('items', undefined);
+    componentRef.setInput('loop', true);
+    fixture.detectChanges();
+
+    expect().nothing();
   });
 
   describe('emitters', () => {

--- a/libs/gallery/src/lib/components/gallery/gallery.component.ts
+++ b/libs/gallery/src/lib/components/gallery/gallery.component.ts
@@ -7,7 +7,9 @@ import {
   HostBinding,
   HostListener,
   Input,
+  OnChanges,
   Output,
+  SimpleChanges,
   TemplateRef,
   ViewChild,
 } from '@angular/core';
@@ -36,7 +38,7 @@ import { ViewerComponent } from '../viewer/viewer.component';
   standalone: true,
   imports: [CommonModule, ThumbsComponent, ViewerComponent],
 })
-export class GalleryComponent {
+export class GalleryComponent implements OnChanges {
   /**
    * Gallery items to display
    */
@@ -187,6 +189,12 @@ export class GalleryComponent {
     return this._galleryColumn
       ? OrientationFlag.HORIZONTAL
       : OrientationFlag.VERTICAL;
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (!changes.items.currentValue) {
+      this.items = [];
+    }
   }
 
   focus() {

--- a/libs/gallery/src/lib/core/ng.ts
+++ b/libs/gallery/src/lib/core/ng.ts
@@ -1,0 +1,6 @@
+import { ComponentRef } from '@angular/core';
+
+export interface StrictComponentRef<C> extends ComponentRef<C> {
+  // `& string` because otherwise keyof would return string | number
+  setInput(name: keyof C & string, value: unknown): void;
+}


### PR DESCRIPTION
The whole codebase relies on `items` being always defined yet this
contract was broken in v3 release.

I use ngOnChanges since a simple default field value is not enough
in cases where `undefined` is assigned to GalleryComponent explicitly.

In the test I started using `setInput` which, unlike simple assignment,
correctly runs ngOnChanges and marks even OnPush component for check.
The default ng's interface for the method is poor however as there is no
`keyof Component` checking so I provided my own to cover this blind spot.
