### PR TITLE
fix(gallery): re-center when items change in loop mode

### DIFF
--- a/libs/gallery/src/lib/components/viewer/viewer.component.cy.ts
+++ b/libs/gallery/src/lib/components/viewer/viewer.component.cy.ts
@@ -1,7 +1,6 @@
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { GalleryItem } from '../../core';
 import { GalleryComponent } from '../gallery/gallery.component';
-import { SLIDE_ANIMATION_DURATION } from './viewer.component';
 
 describe('Slider', () => {
   const items: GalleryItem[] = [
@@ -29,26 +28,22 @@ describe('Slider', () => {
     ensureImagesVisible(1);
   });
 
-  it('displays the first image even when images load later', () => {
+  it('displays the first genuine image even when images load later (loop mode)', () => {
     cy.mount(GalleryComponent, {
-      componentProperties: { items: [] },
+      componentProperties: { items: [], loop: true },
       imports: [BrowserAnimationsModule],
     }).then(({ fixture }) => {
-      // cy.wait(100);
-      cy.log('set non empty items').then(() => {
-        fixture.componentRef.setInput('items', items);
-        // Even though setInput should trigger change detection, it's for some reason still
-        // needed to rerender with the new items.
-        fixture.detectChanges();
-        cy.wait(SLIDE_ANIMATION_DURATION);
-      });
+      cy.wait(0); // simulates a delay in loading the images
+
+      cy.log('set non empty items');
+      cy.then(() => fixture.componentRef.setInput('items', items));
     });
 
     ensureImagesVisible(0);
   });
 
   function ensureImagesVisible(...visibleIndexes: number[]) {
-    cy.get('viewer li img').then(imgs => {
+    cy.get('viewer li:not(.viewer-fringe-item) img').then(imgs => {
       for (let i = 0; i < imgs.length; i++) {
         const img = imgs[i];
         const isVisible = visibleIndexes.includes(i);

--- a/libs/gallery/src/lib/components/viewer/viewer.component.html
+++ b/libs/gallery/src/lib/components/viewer/viewer.component.html
@@ -14,9 +14,10 @@
     #itemsRef
     *ngFor="let item of displayedItems; let i = index"
     media
-    [attr.tabindex]="itemTabbable(i)"
+    [attr.tabindex]="isItemFringe(i) ? -1 : 0"
     [attr.aria-label]="item.alt"
     [attr.aria-describedby]="'viewer-aria-description-' + i"
+    [class.viewer-fringe-item]="isItemFringe(i)"
     (click)="onImageClick(item, $event)"
     (mediaLoadError)="onItemErrored(item)"
     (keydown.Tab)="onTab(i + 1)"

--- a/libs/gallery/src/lib/components/viewer/viewer.component.ts
+++ b/libs/gallery/src/lib/components/viewer/viewer.component.ts
@@ -164,6 +164,11 @@ export class ViewerComponent implements OnChanges, OnInit, AfterViewInit {
     if (items || visibleItems || loop) {
       this.fringeCount = this.getFringeCount();
       this.displayedItems = this.getItemsToBeDisplayed(this.fringeCount);
+
+      if (this.reallyLoop) {
+        this.noAnimation = true;
+        this.center();
+      }
     }
   }
 
@@ -268,9 +273,9 @@ export class ViewerComponent implements OnChanges, OnInit, AfterViewInit {
     return item._failed;
   }
 
-  itemTabbable(index: number) {
+  isItemFringe(index: number) {
     index = index - this.fringeCount;
-    return index >= 0 && index < this.items.length ? 0 : -1;
+    return index < 0 || index >= this.items.length;
   }
 
   private center() {


### PR DESCRIPTION
Before, when items came in later, they were not re-centered and the
fringe item(s) was displayed. So I am centering it and turning off the
animation at the start so that it doesn't look awkward.

I tried to test this last aspect in Cypress but without avail, even when
turning off waitForAnimations. Given Cypress so far sucks for my use
case, since the hot reloading doesn't work, I might consider Playwright.